### PR TITLE
chore(deps): update bun dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -184,7 +184,7 @@
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
-    "@types/react": ["@types/react@19.2.16", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w=="],
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
-        "@types/react": "^19.2.16",
+        "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "jszip": "^3.10.1",
         "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",
-    "@types/react": "^19.2.16",
+    "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "jszip": "^3.10.1",
     "react": "^19.2.7",


### PR DESCRIPTION
## Summary

Updates Bun-managed dependencies with `bun update`.

## Changed files

- bun.lock
- package.json

## bun update output

```text
bun update v1.3.14 (0d9b296a)
Resolving dependencies
Resolved, downloaded and extracted [32]
Saved lockfile

$ vp config

^ @types/react 19.2.16 -> 19.2.17

+ @tailwindcss/forms@0.5.11
+ @tailwindcss/typography@0.5.19
+ @tailwindcss/vite@4.3.0
+ @vitejs/plugin-react@6.0.2
+ typescript@6.0.3
+ vite@0.1.24
+ vite-plus@0.1.24
+ @ffmpeg/ffmpeg@0.12.15
+ @ffmpeg/util@0.12.2
+ @types/react-dom@19.2.3
+ jszip@3.10.1
+ react@19.2.7
+ react-dom@19.2.7
+ tailwindcss@4.3.0

87 packages installed [1.95s]
```

## Testing

- [ ] Not run; dependency update only
